### PR TITLE
Bug 1986474: Fix vsphere-syncer build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ else
 CONTROLLER_GEN=$(shell which controller-gen)
 endif
 
-$(SYNCER_BIN): $(SYNCER_BIN_SRCS) syncer_manifest
+$(SYNCER_BIN): $(SYNCER_BIN_SRCS)
 	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) go build $(GOFLAGS_VENDOR) -ldflags '$(LDFLAGS_SYNCER)' -o $(abspath $@) $<
 	@touch $@
 


### PR DESCRIPTION
Builds of the syncer image have been failing recently:

```
-> WORKDIR /go/src/github.com/kubernetes-sigs/vsphere-csi-driver
--> COPY . .
--> RUN make build # TODO: build only driver
which: no controller-gen in (/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin)
CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -mod=vendor -ldflags '-extldflags "-static" -w -s -X "sigs.k8s.io/vsphere-csi-driver/pkg/csi/service.Version=1.16"' -o /go/src/github.com/kubernetes-sigs/vsphere-csi-driver/.build/bin/vsphere-csi.linux_amd64 cmd/vsphere-csi/main.go
go: creating new go.mod: module tmp
go get: sigs.k8s.io/controller-tools/cmd/controller-gen@v0.2.5: Get "https://proxy.golang.org/sigs.k8s.io/controller-tools/cmd/controller-gen/@v/v0.2.5.info": dial tcp 142.251.45.17:443: connect: connection refused
make: *** [Makefile:128: controller-gen] Error 1
```

Which tells me the build process (understandably) doesn't allow internet access.

I can reproduce the issue with:

```
$ podman build --network=none --authfile=/home/fbertina/cluster/pull.json -t blah -f Dockerfile.syncer.openshift
(...)
go: creating new go.mod: module tmp
go get: sigs.k8s.io/controller-tools/cmd/controller-gen@v0.2.5: Get "https://proxy.golang.org/sigs.k8s.io/controller-tools/cmd/controller-gen/@v/v0.2.5.info": dial tcp: lookup proxy.golang.org: no such host
```

With this patch:

```
$ podman build --network=none --authfile=/home/fbertina/cluster/pull.json -t blah -f Dockerfile.syncer.openshift
(...)
Successfully tagged localhost/blah:latest
bb5430f09faf259311311f1a4947c967bae930f0f56773314f052996d6e981c6
```

CC @openshift/storage 