### PR TITLE
WIP: UPSTREAM: 1451: Fix parsing of volume path

### DIFF
--- a/pkg/apis/migration/migration.go
+++ b/pkg/apis/migration/migration.go
@@ -378,7 +378,7 @@ func (volumeMigration *volumeMigration) registerVolume(ctx context.Context, volu
 			"failed to extract datastore name from in-tree volume path: %q", volumeSpec.VolumePath)
 	}
 	datastoreFullPath := re.FindAllString(volumeSpec.VolumePath, -1)[0]
-	vmdkPath := strings.TrimSpace(strings.Trim(volumeSpec.VolumePath, datastoreFullPath))
+	vmdkPath := strings.TrimSpace(strings.TrimPrefix(volumeSpec.VolumePath, datastoreFullPath))
 	datastoreFullPath = strings.Trim(strings.Trim(datastoreFullPath, "["), "]")
 	datastorePathSplit := strings.Split(datastoreFullPath, "/")
 	datastoreName := datastorePathSplit[len(datastorePathSplit)-1]


### PR DESCRIPTION
Remove datastore name from VolumePath using TrimPrefix. Trim will remove all
matching characters from the end of the VolumePath, e.g. it can remove
"vmdk" if the datastore name contains charactes "v", "m", "d" and "k"
(anywhere in the datastore name).


WIP: waiting for https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/1451 merged upstream.