### PR TITLE
WIP: Fixed parsing of /proc/self/mountinfo with spaces

### DIFF
--- a/pkg/csi/service/osutils/linux_os_utils_test.go
+++ b/pkg/csi/service/osutils/linux_os_utils_test.go
@@ -1,0 +1,47 @@
+//go:build darwin || linux
+// +build darwin linux
+
+package osutils
+
+import (
+	"strconv"
+	"testing"
+)
+
+func TestUnescape(t *testing.T) {
+	tests := []struct {
+		in, out string
+	}{
+		{
+			// Space is unescaped. This is basically the only test that can happen in reality.
+			in:  `/var/lib/kubelet/plugins/kubernetes.io/csi/pv/csi.vsphere.vmware.com-[WorkloadDatastore]\0405137595f-7ce3-e95a-5c03-06d835dea807/e2e-vmdk-1641374604660540311.vmdk/globalmount`,
+			out: `/var/lib/kubelet/plugins/kubernetes.io/csi/pv/csi.vsphere.vmware.com-[WorkloadDatastore] 5137595f-7ce3-e95a-5c03-06d835dea807/e2e-vmdk-1641374604660540311.vmdk/globalmount`,
+		},
+		{
+			// Multiple spaces are unescaped.
+			in:  `/var/lib/kube\040let/plug\040ins/kubernetes.io/csi/pv/csi.vsphere.vmware.com-foo\040bar\040baz`,
+			out: `/var/lib/kube let/plug ins/kubernetes.io/csi/pv/csi.vsphere.vmware.com-foo bar baz`,
+		},
+		{
+			// Too short escape sequence. Expect the same string on output.
+			in:  `/var/lib/kubelet/plugins/kubernetes.io/csi/pv/foo\04`,
+			out: `/var/lib/kubelet/plugins/kubernetes.io/csi/pv/foo\04`,
+		},
+		{
+			// Wrong characters in the escape sequence. Expect the same string on output.
+			in:  `/var/lib/kubelet/plugins/kubernetes.io/csi/pv/foo\0bc`,
+			out: `/var/lib/kubelet/plugins/kubernetes.io/csi/pv/foo\0bc`,
+		},
+	}
+
+	for i, test := range tests {
+		test := test
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			t.Parallel()
+			out := unescape(test.in)
+			if out != test.out {
+				t.Errorf("Expected %q to be unescaped as %q, got %q", test.in, test.out, out)
+			}
+		})
+	}
+}


### PR DESCRIPTION
When a mount point contains space, it is escaped in /proc/self/mountifo as
\040:

7331 6783 8:32 / /var/lib/kubelet/plugins/kubernetes.io/csi/pv/csi.vsphere.vmware.com-[WorkloadDatastore]\0405137595f-7ce3-e95a-5c03-06d835dea807/e2e-vmdk-1641374604660540311.vmdk/globalmount rw,relatime - ext4 /dev/sdc rw,seclabel

Un-escape this sequence (and any other \nnn sequences) before comparing the
parsed mount path.

This happens only for in-line in-tree vSphere volumes when CSI migration is
enabled. Whole '[WorkloadDatastore] 5137595f-7ce3-e95a-5c03-06d835dea807/e2e-vmdk-1641374604660540311.vmdk'
is used as volumeHandle (and thus in global mount dir) and as a fake PV name (and
thus is in pod local mount dir).

WIP: testing before pushing upstream.