### PR TITLE
Bug 2029835: Revert "Merge pull request #30 from bertinatto/rebase-v2.4.1"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ CSI_BIN_NAME := vsphere-csi
 CSI_BIN := $(BIN_OUT)/$(CSI_BIN_NAME).$(GOOS)_$(GOARCH)
 CSI_BIN_LINUX := $(BIN_OUT)/$(CSI_BIN_NAME).linux_$(GOARCH)
 CSI_BIN_WINDOWS := $(BIN_OUT)/$(CSI_BIN_NAME).windows_$(GOARCH)
-build-csi: $(CSI_BIN) 
+build-csi: $(CSI_BIN)
 build-csi-windows: $(CSI_BIN_WINDOWS)
 ifndef CSI_BIN_SRCS
 CSI_BIN_SRCS := cmd/$(CSI_BIN_NAME)/main.go go.mod go.sum
@@ -415,7 +415,7 @@ images: | $(DOCKER_SOCK)
 push-images: | $(DOCKER_SOCK)
 ifndef CSI_REGISTRY
 	hack/release.sh -p
-else 
+else
 	hack/release.sh -p -r ${CSI_REGISTRY}
 endif
 

--- a/manifests/vanilla/validatingwebhook.yaml
+++ b/manifests/vanilla/validatingwebhook.yaml
@@ -101,7 +101,7 @@ spec:
       dnsPolicy: "Default"
       containers:
         - name: vsphere-webhook
-          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.4.1
+          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.4.0
           args:
             - "--operation-mode=WEBHOOK_SERVER"
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"

--- a/manifests/vanilla/vsphere-csi-driver.yaml
+++ b/manifests/vanilla/vsphere-csi-driver.yaml
@@ -255,7 +255,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: vsphere-csi-controller
-          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.4.1
+          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.4.0
           args:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
@@ -312,7 +312,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: vsphere-syncer
-          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.4.1
+          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.4.0
           args:
             - "--leader-election"
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
@@ -416,7 +416,7 @@ spec:
               - --mode=kubelet-registration-probe
             initialDelaySeconds: 3
         - name: vsphere-csi-node
-          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.4.1
+          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.4.0
           args:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
@@ -563,7 +563,7 @@ spec:
               - --mode=kubelet-registration-probe
             initialDelaySeconds: 3
         - name: vsphere-csi-node
-          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.4.1
+          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.4.0
           args:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"

--- a/pkg/apis/migration/migration.go
+++ b/pkg/apis/migration/migration.go
@@ -18,7 +18,6 @@ package migration
 
 import (
 	"context"
-	"errors"
 	"net/url"
 	"regexp"
 	"strings"
@@ -53,18 +52,13 @@ type VolumeSpec struct {
 	StoragePolicyName string
 }
 
-// ErrVolumeIDNotFound is returned when volume is not found from the VolumeMigrationService Cache
-var ErrVolumeIDNotFound = errors.New("could not retrieve VolumeID from VolumeMigrationService cache")
-
 // VolumeMigrationService exposes interfaces to support VCP to CSI migration.
 // It will maintain internal state to map volume path to volume ID and reverse
 // mapping.
 type VolumeMigrationService interface {
 	// GetVolumeID returns VolumeID for a given VolumeSpec.
-	// When volume is not found in the cache, if registerIfNotFound is set to true, volume registration will be invoked
-	// and mapping will be preserved and VolumeID will be returned to the caller
-	// Returns an error if not able to retrieve/register Volume.
-	GetVolumeID(ctx context.Context, volumeSpec *VolumeSpec, registerIfNotFound bool) (string, error)
+	// Returns an error if not able to retrieve VolumeID.
+	GetVolumeID(ctx context.Context, volumeSpec *VolumeSpec) (string, error)
 
 	// GetVolumePath returns VolumePath for a given VolumeID.
 	// Returns an error if not able to retrieve VolumePath.
@@ -80,8 +74,6 @@ type VolumeMigrationService interface {
 type volumeMigration struct {
 	// volumePath to volumeId map.
 	volumePathToVolumeID sync.Map
-	// mutexes for registerVolume API
-	registerVolumeMutexes sync.Map
 	// k8sClient helps operate on CnsVSphereVolumeMigration custom resource.
 	k8sClient client.Client
 	// volumeManager helps perform Volume Operations.
@@ -92,8 +84,14 @@ type volumeMigration struct {
 }
 
 const (
+	// CRDName represent the name of cnsvspherevolumemigrations CRD.
+	CRDName = "cnsvspherevolumemigrations.cns.vmware.com"
 	// CRDGroupName represent the group of cnsvspherevolumemigrations CRD.
 	CRDGroupName = "cns.vmware.com"
+	// CRDSingular represent the singular name of cnsvspherevolumemigrations CRD.
+	CRDSingular = "cnsvspherevolumemigration"
+	// CRDPlural represent the plural name of cnsvspherevolumemigrations CRD.
+	CRDPlural = "cnsvspherevolumemigrations"
 )
 
 var (
@@ -198,41 +196,38 @@ func GetVolumeMigrationService(ctx context.Context, volumeManager *cnsvolume.Man
 	return volumeMigrationInstance, nil
 }
 
-// GetVolumeID returns VolumeID for a given VolumeSpec.
-// When volume is not found in the cache, if registerIfNotFound is set to true, volume registration will be invoked
-// and mapping will be preserved and VolumeID will be returned to the caller
-// Returns an error if not able to retrieve/register Volume.
-func (volumeMigration *volumeMigration) GetVolumeID(ctx context.Context, volumeSpec *VolumeSpec,
-	registerIfNotFound bool) (string, error) {
+// GetVolumeID returns VolumeID for given VolumeSpec.
+// Returns an error if not able to retrieve VolumeID.
+func (volumeMigration *volumeMigration) GetVolumeID(ctx context.Context, volumeSpec *VolumeSpec) (string, error) {
 	log := logger.GetLogger(ctx)
 	info, found := volumeMigration.volumePathToVolumeID.Load(volumeSpec.VolumePath)
 	if found {
 		log.Debugf("VolumeID: %q found from the cache for VolumePath: %q", info.(string), volumeSpec.VolumePath)
 		return info.(string), nil
 	}
-	if registerIfNotFound {
-		volumeID, err := volumeMigration.registerVolume(ctx, volumeSpec)
-		if err != nil {
-			log.Errorf("failed to register volume for volumeSpec: %v, with err: %v", volumeSpec, err)
-			return "", err
-		}
-		log.Infof("Successfully registered volumeSpec: %v with CNS. VolumeID: %v", volumeSpec, volumeID)
-		cnsvSphereVolumeMigration := migrationv1alpha1.CnsVSphereVolumeMigration{
-			ObjectMeta: metav1.ObjectMeta{Name: volumeID},
-			Spec: migrationv1alpha1.CnsVSphereVolumeMigrationSpec{
-				VolumePath: volumeSpec.VolumePath,
-				VolumeID:   volumeID,
-			},
-		}
-		log.Debugf("Saving cnsvSphereVolumeMigration CR: %v", cnsvSphereVolumeMigration)
-		err = volumeMigration.saveVolumeInfo(ctx, &cnsvSphereVolumeMigration)
-		if err != nil {
-			log.Errorf("failed to save cnsvSphereVolumeMigration CR:%v, err: %v", cnsvSphereVolumeMigration, err)
-			return "", err
-		}
-		return volumeID, nil
+	// Volume may not be registered.
+	log.Infof("Could not retrieve VolumeID from cache for Volume Path: %q. Registering Volume with CNS",
+		volumeSpec.VolumePath)
+	volumeID, err := volumeMigration.registerVolume(ctx, volumeSpec)
+	if err != nil {
+		log.Errorf("failed to register volume for volumeSpec: %v, with err: %v", volumeSpec, err)
+		return "", err
 	}
-	return "", ErrVolumeIDNotFound
+	log.Infof("Successfully registered volumeSpec: %v with CNS. VolumeID: %v", volumeSpec, volumeID)
+	cnsvSphereVolumeMigration := migrationv1alpha1.CnsVSphereVolumeMigration{
+		ObjectMeta: metav1.ObjectMeta{Name: volumeID},
+		Spec: migrationv1alpha1.CnsVSphereVolumeMigrationSpec{
+			VolumePath: volumeSpec.VolumePath,
+			VolumeID:   volumeID,
+		},
+	}
+	log.Debugf("Saving cnsvSphereVolumeMigration CR: %v", cnsvSphereVolumeMigration)
+	err = volumeMigration.saveVolumeInfo(ctx, &cnsvSphereVolumeMigration)
+	if err != nil {
+		log.Errorf("failed to save cnsvSphereVolumeMigration CR:%v, err: %v", err)
+		return "", err
+	}
+	return volumeID, nil
 }
 
 // GetVolumePath returns VolumePath for given VolumeID.
@@ -319,7 +314,7 @@ func (volumeMigration *volumeMigration) GetVolumePath(ctx context.Context, volum
 	log.Debugf("Saving cnsvSphereVolumeMigration CR: %v", cnsvSphereVolumeMigration)
 	err = volumeMigration.saveVolumeInfo(ctx, &cnsvSphereVolumeMigration)
 	if err != nil {
-		log.Errorf("failed to save cnsvSphereVolumeMigration CR:%v, err: %v", cnsvSphereVolumeMigration, err)
+		log.Errorf("failed to save cnsvSphereVolumeMigration CR:%v, err: %v", err)
 		return "", err
 	}
 	return fileBackingInfo.FilePath, nil
@@ -372,11 +367,6 @@ func (volumeMigration *volumeMigration) DeleteVolumeInfo(ctx context.Context, vo
 // Returns VolumeID for successful registration, otherwise return error.
 func (volumeMigration *volumeMigration) registerVolume(ctx context.Context, volumeSpec *VolumeSpec) (string, error) {
 	log := logger.GetLogger(ctx)
-	value, _ := volumeMigration.registerVolumeMutexes.LoadOrStore(volumeSpec.VolumePath, &sync.Mutex{})
-	mtx := value.(*sync.Mutex)
-	mtx.Lock()
-	defer mtx.Unlock()
-
 	uuid, err := uuid.NewUUID()
 	if err != nil {
 		log.Errorf("failed to generate uuid")

--- a/pkg/common/cns-lib/vsphere/virtualcentermanager.go
+++ b/pkg/common/cns-lib/vsphere/virtualcentermanager.go
@@ -52,6 +52,8 @@ type VirtualCenterManager interface {
 	UnregisterAllVirtualCenters(ctx context.Context) error
 	// IsvSANFileServicesSupported checks if vSAN file services is supported or not.
 	IsvSANFileServicesSupported(ctx context.Context, host string) (bool, error)
+	// IsExtendVolumeSupported checks if extend volume is supported or not.
+	IsExtendVolumeSupported(ctx context.Context, host string) (bool, error)
 	// IsOnlineExtendVolumeSupported checks if online extend volume is supported
 	// or not on the vCenter Host.
 	IsOnlineExtendVolumeSupported(ctx context.Context, host string) (bool, error)
@@ -156,6 +158,17 @@ func (m *defaultVirtualCenterManager) UnregisterAllVirtualCenters(ctx context.Co
 
 // IsvSANFileServicesSupported checks if vSAN file services is supported or not.
 func (m *defaultVirtualCenterManager) IsvSANFileServicesSupported(ctx context.Context, host string) (bool, error) {
+	log := logger.GetLogger(ctx)
+	is67u3Release, err := isVsan67u3Release(ctx, m, host)
+	if err != nil {
+		log.Errorf("Failed to identify the vCenter release with error: %+v", err)
+		return false, err
+	}
+	return !is67u3Release, nil
+}
+
+// IsExtendVolumeSupported checks if extend volume is supported or not.
+func (m *defaultVirtualCenterManager) IsExtendVolumeSupported(ctx context.Context, host string) (bool, error) {
 	log := logger.GetLogger(ctx)
 	is67u3Release, err := isVsan67u3Release(ctx, m, host)
 	if err != nil {

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -27,7 +27,6 @@ import (
 	"strings"
 
 	"gopkg.in/gcfg.v1"
-	corev1 "k8s.io/api/core/v1"
 
 	cnstypes "github.com/vmware/govmomi/cns/types"
 	vsanfstypes "github.com/vmware/govmomi/vsan/vsanfs/types"
@@ -81,9 +80,6 @@ const (
 	DefaultGlobalMaxSnapshotsPerBlockVolume = 3
 	// MaxNumberOfTopologyCategories is the max number of topology domains/categories allowed.
 	MaxNumberOfTopologyCategories = 5
-	// TopologyLabelsDomain is the domain name used to identify user-defined
-	// topology labels applied on the node by vSphere CSI driver.
-	TopologyLabelsDomain = "topology.csi.vmware.com"
 )
 
 // Errors
@@ -391,17 +387,6 @@ func validateConfig(ctx context.Context, cfg *Config) error {
 		if len(strings.Split(cfg.Labels.TopologyCategories, ",")) > MaxNumberOfTopologyCategories {
 			return logger.LogNewErrorf(log, "maximum limit of topology categories exceeded. Only %d allowed.",
 				MaxNumberOfTopologyCategories)
-		}
-	}
-
-	// Validate topology labels specified in TopologyCategory section.
-	betaDomain := strings.Split(corev1.LabelFailureDomainBetaZone, "/")[0]
-	gaDomain := strings.Split(corev1.LabelTopologyZone, "/")[0]
-	for key, categoryInfo := range cfg.TopologyCategory {
-		topoDomain := strings.Split(categoryInfo.Label, "/")[0]
-		if topoDomain != betaDomain && topoDomain != gaDomain && topoDomain != TopologyLabelsDomain {
-			return logger.LogNewErrorf(log, "unrecognised topology label %q used for topology category %q",
-				categoryInfo.Label, key)
 		}
 	}
 

--- a/pkg/common/config/types.go
+++ b/pkg/common/config/types.go
@@ -88,8 +88,6 @@ type Config struct {
 		// Maximum number of categories allowed is 5.
 		TopologyCategories string `gcfg:"topology-categories"`
 	}
-
-	TopologyCategory map[string]*TopologyCategoryInfo
 }
 
 // ConfigurationInfo is a struct that used to capture config param details
@@ -101,11 +99,6 @@ type ConfigurationInfo struct {
 type FeatureStatesConfigInfo struct {
 	Name      string
 	Namespace string
-}
-
-// TopologyCategoryInfo contains metadata for the Zone and Region parameters under Labels section.
-type TopologyCategoryInfo struct {
-	Label string `gcfg:"label"`
 }
 
 // NetPermissionConfig consists of information used to restrict the

--- a/pkg/csi/service/common/commonco/k8sorchestrator/topology.go
+++ b/pkg/csi/service/common/commonco/k8sorchestrator/topology.go
@@ -661,8 +661,6 @@ func (volTopology *controllerVolumeTopology) GetTopologyInfoFromNodes(ctx contex
 	log.Infof("Topology segments retrieved from nodes accessible to datastore %q are: %+v", datastoreURL,
 		topologySegments)
 
-	// Check for each calculated topology segment if all nodes in that segment have access to this datastore.
-	// This check will filter out topology segments in which all nodes do not have access to the chosen datastore.
 	accessibleTopology, err := verifyAllNodesInTopologyAccessibleToDatastore(ctx, nodeNames,
 		datastoreURL, topologySegments)
 	if err != nil {

--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -882,7 +882,7 @@ func (c *controller) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeRequ
 				// Error is already wrapped in CSI error code.
 				return nil, csifault.CSIInternalFault, err
 			}
-			req.VolumeId, err = volumeMigrationService.GetVolumeID(ctx, &migration.VolumeSpec{VolumePath: req.VolumeId}, false)
+			req.VolumeId, err = volumeMigrationService.GetVolumeID(ctx, &migration.VolumeSpec{VolumePath: req.VolumeId})
 			if err != nil {
 				return nil, csifault.CSIInternalFault, logger.LogNewErrorCodef(log, codes.Internal,
 					"failed to get VolumeID from volumeMigrationService for volumePath: %q", volumePath)
@@ -1021,7 +1021,7 @@ func (c *controller) ControllerPublishVolume(ctx context.Context, req *csi.Contr
 					return nil, csifault.CSIInternalFault, err
 				}
 				req.VolumeId, err = volumeMigrationService.GetVolumeID(ctx,
-					&migration.VolumeSpec{VolumePath: volumePath, StoragePolicyName: storagePolicyName}, false)
+					&migration.VolumeSpec{VolumePath: volumePath, StoragePolicyName: storagePolicyName})
 				if err != nil {
 					return nil, csifault.CSIInternalFault, logger.LogNewErrorCodef(log, codes.Internal,
 						"failed to get VolumeID from volumeMigrationService for volumePath: %q", volumePath)
@@ -1138,7 +1138,7 @@ func (c *controller) ControllerUnpublishVolume(ctx context.Context, req *csi.Con
 				// Error is already wrapped in CSI error code.
 				return nil, csifault.CSIInternalFault, err
 			}
-			req.VolumeId, err = volumeMigrationService.GetVolumeID(ctx, &migration.VolumeSpec{VolumePath: volumePath}, false)
+			req.VolumeId, err = volumeMigrationService.GetVolumeID(ctx, &migration.VolumeSpec{VolumePath: volumePath})
 			if err != nil {
 				return nil, csifault.CSIInternalFault, logger.LogNewErrorCodef(log, codes.Internal,
 					"failed to get VolumeID from volumeMigrationService for volumePath: %q", volumePath)
@@ -1189,6 +1189,17 @@ func (c *controller) ControllerExpandVolume(ctx context.Context, req *csi.Contro
 	if strings.Contains(req.VolumeId, ".vmdk") {
 		return nil, logger.LogNewErrorCodef(log, codes.Unimplemented,
 			"cannot expand migrated vSphere volume. :%q", req.VolumeId)
+	}
+
+	isExtendSupported, err := c.manager.VcenterManager.IsExtendVolumeSupported(ctx, c.manager.VcenterConfig.Host)
+	if err != nil {
+		return nil, logger.LogNewErrorCodef(log, codes.Internal,
+			"failed to verify if extend volume is supported or not. Error: %+v", err)
+	}
+	if !isExtendSupported {
+		return nil, logger.LogNewErrorCode(log, codes.Internal,
+			"volume Expansion is not supported in this vSphere release. "+
+				"Upgrade to vSphere 7.0 for offline expansion and vSphere 7.0U2 for online expansion support.")
 	}
 
 	isOnlineExpansionSupported, err := c.manager.VcenterManager.IsOnlineExtendVolumeSupported(ctx,

--- a/pkg/syncer/cnsoperator/controller/csinodetopology/controller_test.go
+++ b/pkg/syncer/cnsoperator/controller/csinodetopology/controller_test.go
@@ -1,0 +1,191 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package csinodetopology
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/vsphere-csi-driver/v2/pkg/csi/service/common"
+)
+
+func TestFindExistingTopologyLabels(t *testing.T) {
+	ctx := context.Background()
+	tests := []struct {
+		name                string
+		nodeList            []corev1.Node
+		expectedZoneLabel   string
+		expectedRegionLabel string
+		expectedErr         bool
+	}{
+		{
+			name: "ExpectedGALabels",
+			nodeList: []corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							corev1.LabelTopologyZone:   "zone1",
+							corev1.LabelTopologyRegion: "regionA",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							corev1.LabelTopologyZone:   "zone2",
+							corev1.LabelTopologyRegion: "regionB",
+						},
+					},
+				},
+			},
+			expectedZoneLabel:   corev1.LabelTopologyZone,
+			expectedRegionLabel: corev1.LabelTopologyRegion,
+			expectedErr:         false,
+		},
+		{
+			name: "ExpectedPartialGALabels",
+			nodeList: []corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							common.TopologyLabelsDomain + "/zone":   "zone1",
+							common.TopologyLabelsDomain + "/region": "regionA",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							corev1.LabelTopologyZone: "zone2",
+						},
+					},
+				},
+			},
+			expectedZoneLabel:   corev1.LabelTopologyZone,
+			expectedRegionLabel: corev1.LabelTopologyRegion,
+			expectedErr:         false,
+		},
+		{
+			name: "ExpectedBetaLabels",
+			nodeList: []corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							corev1.LabelFailureDomainBetaZone:   "zone1",
+							corev1.LabelFailureDomainBetaRegion: "regionA",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							corev1.LabelFailureDomainBetaZone:   "zone2",
+							corev1.LabelFailureDomainBetaRegion: "regionB",
+						},
+					},
+				},
+			},
+			expectedZoneLabel:   corev1.LabelFailureDomainBetaZone,
+			expectedRegionLabel: corev1.LabelFailureDomainBetaRegion,
+			expectedErr:         false,
+		},
+		{
+			name: "ExpectedPartialBetaLabels",
+			nodeList: []corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							corev1.LabelFailureDomainBetaZone:   "zone1",
+							corev1.LabelFailureDomainBetaRegion: "regionA",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							common.TopologyLabelsDomain + "/zone":   "zone2",
+							common.TopologyLabelsDomain + "/region": "regionB",
+						},
+					},
+				},
+			},
+			expectedZoneLabel:   corev1.LabelFailureDomainBetaZone,
+			expectedRegionLabel: corev1.LabelFailureDomainBetaRegion,
+			expectedErr:         false,
+		},
+		{
+			name: "MixedLabelsOnNodes",
+			nodeList: []corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							corev1.LabelFailureDomainBetaZone:   "zone1",
+							corev1.LabelFailureDomainBetaRegion: "regionA",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							corev1.LabelTopologyZone:   "zone2",
+							corev1.LabelTopologyRegion: "regionB",
+						},
+					},
+				},
+			},
+			expectedZoneLabel:   "",
+			expectedRegionLabel: "",
+			expectedErr:         true,
+		},
+		{
+			name: "NoStandardLabelsOnNodes",
+			nodeList: []corev1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							common.TopologyLabelsDomain + "/zone":   "zone1",
+							common.TopologyLabelsDomain + "/region": "regionA",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							common.TopologyLabelsDomain + "/zone":   "zone2",
+							common.TopologyLabelsDomain + "/region": "regionB",
+						},
+					},
+				},
+			},
+			expectedZoneLabel:   "",
+			expectedRegionLabel: "",
+			expectedErr:         false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actualZoneLabel, actualRegionLabel, actualErr := findExistingTopologyLabels(ctx, tt.nodeList)
+			assert.Equal(t, tt.expectedErr, actualErr != nil)
+			assert.Equal(t, tt.expectedZoneLabel, actualZoneLabel)
+			assert.Equal(t, tt.expectedRegionLabel, actualRegionLabel)
+		})
+	}
+}

--- a/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller.go
+++ b/pkg/syncer/cnsoperator/controller/csinodetopology/csinodetopology_controller.go
@@ -26,6 +26,7 @@ import (
 	cnstypes "github.com/vmware/govmomi/cns/types"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -263,7 +264,7 @@ func (r *ReconcileCSINodeTopology) Reconcile(ctx context.Context, request reconc
 	backOffDurationMapMutex.Lock()
 	delete(backOffDuration, instance.Name)
 	backOffDurationMapMutex.Unlock()
-	log.Infof("Successfully updated topology labels for nodeVM %q", instance.Name)
+	log.Infof("Successfully updated topology labels for nodeVM %q", instance.Name, nodeID)
 	return reconcile.Result{}, nil
 }
 
@@ -324,54 +325,80 @@ func getNodeTopologyInfo(ctx context.Context, nodeVM *cnsvsphere.VirtualMachine,
 		}
 	}()
 
-	// Create a map of TopologyCategories with category as key and value as empty string.
+	// Create a map of topologyCategories with category as key and value as empty string.
 	var isZoneRegion bool
-	topologyCategoriesMap := make(map[string]string)
-
 	zoneCat := strings.TrimSpace(cfg.Labels.Zone)
 	regionCat := strings.TrimSpace(cfg.Labels.Region)
+	topologyCategories := make(map[string]string)
 	if strings.TrimSpace(cfg.Labels.TopologyCategories) != "" {
 		categories := strings.Split(cfg.Labels.TopologyCategories, ",")
 		for _, cat := range categories {
-			topologyCategoriesMap[strings.TrimSpace(cat)] = ""
+			topologyCategories[strings.TrimSpace(cat)] = ""
 		}
 	} else if zoneCat != "" && regionCat != "" {
 		isZoneRegion = true
-		topologyCategoriesMap[zoneCat] = ""
-		topologyCategoriesMap[regionCat] = ""
+		topologyCategories[zoneCat] = ""
+		topologyCategories[regionCat] = ""
 	}
 
-	// Populate topology labels for NodeVM corresponding to each category in topologyCategoriesMap map.
-	err = nodeVM.GetTopologyLabels(ctx, tagManager, topologyCategoriesMap)
+	// Populate topology labels for NodeVM corresponding to each category in topologyCategories map.
+	err = nodeVM.GetTopologyLabels(ctx, tagManager, topologyCategories)
 	if err != nil {
 		log.Errorf("failed to get accessibleTopology for nodeVM: %v, Error: %v", nodeVM.Reference(), err)
 		return nil, err
 	}
-	log.Infof("NodeVM %q belongs to topology: %+v", nodeVM.Reference(), topologyCategoriesMap)
+	log.Infof("NodeVM %q belongs to topology: %+v", nodeVM.Reference(), topologyCategories)
 	topologyLabels := make([]csinodetopologyv1alpha1.TopologyLabel, 0)
-	// When zone and region parameters are used in vSphere config,
-	// read the TopologyCategory for labels.
 	if isZoneRegion {
-		var zoneLabel, regionLabel string
-		// Read zone label, default to standard beta labels if not mentioned.
-		zoneInfo, exists := cfg.TopologyCategory[zoneCat]
-		if exists {
-			zoneLabel = zoneInfo.Label
-		} else {
-			log.Infof("No label information for zone provided in the vSphere config secret, "+
-				"defaulting to standard topology beta label - %q", corev1.LabelFailureDomainBetaZone)
-			zoneLabel = corev1.LabelFailureDomainBetaZone
+		// Create the kubernetes client.
+		k8sClient, err := k8s.NewClient(ctx)
+		if err != nil {
+			log.Errorf("failed to create K8s client. Error: %v", err)
+			return nil, err
 		}
-		// Read region label, default to standard beta labels if not mentioned.
-		regionInfo, exists := cfg.TopologyCategory[regionCat]
-		if exists {
-			regionLabel = regionInfo.Label
-		} else {
-			log.Infof("No label information for region provided in the vSphere config secret, "+
-				"defaulting to standard topology beta label - %q", corev1.LabelFailureDomainBetaRegion)
-			regionLabel = corev1.LabelFailureDomainBetaRegion
+
+		// In order to keep backward compatibility, we will discover existing topology labels
+		// on nodes in the cluster. Few examples on how the discovery works:
+		// Node    Topology label
+		// N1      topology.kubernetes.io/XYZ
+		// N2      topology.kubernetes.io/XYZ
+		// After the cluster is up and running, N1 and N2 will have topology labels of the
+		// form `topology.kubernetes.io/XYZ`
+		//
+		// Node    Topology label
+		// N1      failure-domain.beta.kubernetes.io/XYZ
+		// N2      No label
+		// After the cluster is up and running, N1 and N2 will have topology labels of the
+		// form `failure-domain.beta.kubernetes.io/XYZ`
+		//
+		// Node    Topology label
+		// N1      failure-domain.beta.kubernetes.io/XYZ
+		// N2      topology.kubernetes.io/XYZ
+		// The nodes in the cluster will remain in CrashLoopBackOff state till the customer
+		// intervenes to have a uniform label across all nodes in the cluster.
+		//
+		// Node    Topology label
+		// N1      No label
+		// N2      No label
+		// After the cluster is up and running, N1 and N2 will have topology labels of the
+		// form `topology.csi.vmware.com/XYZ`
+		nodeList, err := k8sClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return nil, logger.LogNewErrorf(log, "failed to list nodes in the cluster. Error: %+v", err)
 		}
-		for key, val := range topologyCategoriesMap {
+		zoneLabel, regionLabel, err := findExistingTopologyLabels(ctx, nodeList.Items)
+		if err != nil {
+			return nil, logger.LogNewErrorf(log, "failed to discover existing topology labels "+
+				"on the nodes in the cluster. Error: %+v", err)
+		}
+		if zoneLabel == "" && regionLabel == "" {
+			log.Infof("Did not find any existing standard topology labels on the nodes in the " +
+				"cluster, using VMware CSI topology labels instead.")
+			zoneLabel = common.TopologyLabelsDomain + "/" + zoneCat
+			regionLabel = common.TopologyLabelsDomain + "/" + regionCat
+		}
+
+		for key, val := range topologyCategories {
 			switch key {
 			case zoneCat:
 				topologyLabels = append(topologyLabels,
@@ -384,10 +411,47 @@ func getNodeTopologyInfo(ctx context.Context, nodeVM *cnsvsphere.VirtualMachine,
 	} else {
 		// Prefix user-defined topology labels with TopologyLabelsDomain name to distinctly
 		// identify the topology labels on the kubernetes node object added by our driver.
-		for key, val := range topologyCategoriesMap {
+		for key, val := range topologyCategories {
 			topologyLabels = append(topologyLabels,
 				csinodetopologyv1alpha1.TopologyLabel{Key: common.TopologyLabelsDomain + "/" + key, Value: val})
 		}
 	}
 	return topologyLabels, nil
+}
+
+// findExistingTopologyLabels figures out if the given list of nodes were already participating
+// in a topology setup. If yes, it will discover if the nodes use the standard topology beta
+// labels or the GA labels and return those. However, if the cluster has a mix of nodes with beta
+// and GA labels, it will error out and request the customer to fix the environment before proceeding
+// further. If no topology labels were found on all nodes, it will return empty strings.
+func findExistingTopologyLabels(ctx context.Context, nodeList []corev1.Node) (string, string, error) {
+	log := logger.GetLogger(ctx)
+	labelMap := map[string]bool{
+		"beta": false,
+		"GA":   false,
+	}
+	for _, k8sNode := range nodeList {
+		if k8sNode.Labels[corev1.LabelTopologyZone] != "" || k8sNode.Labels[corev1.LabelTopologyRegion] != "" {
+			labelMap["GA"] = true
+		}
+		if k8sNode.Labels[corev1.LabelFailureDomainBetaZone] != "" ||
+			k8sNode.Labels[corev1.LabelFailureDomainBetaRegion] != "" {
+			labelMap["beta"] = true
+		}
+		if labelMap["GA"] && labelMap["beta"] {
+			return "", "", logger.LogNewErrorf(log, "found conflicting topology labels on certain node(s) in "+
+				"the cluster. Nodes in the cluster should either have the standard topology beta labels "+
+				"starting with \"failure-domain.beta.kubernetes.io\" or standard topology GA labels starting with "+
+				"\"topology.kubernetes.io\".")
+		}
+	}
+	switch {
+	case labelMap["GA"]:
+		log.Infof("Found standard topology GA labels on the existing nodes in the cluster.")
+		return corev1.LabelTopologyZone, corev1.LabelTopologyRegion, nil
+	case labelMap["beta"]:
+		log.Infof("Found standard topology beta labels on the existing nodes in the cluster.")
+		return corev1.LabelFailureDomainBetaZone, corev1.LabelFailureDomainBetaRegion, nil
+	}
+	return "", "", nil
 }

--- a/pkg/syncer/fullsync.go
+++ b/pkg/syncer/fullsync.go
@@ -73,7 +73,7 @@ func CsiFullSync(ctx context.Context, metadataSyncer *metadataSyncInformer) erro
 			migrationVolumeSpec := &migration.VolumeSpec{
 				VolumePath:        pv.Spec.VsphereVolume.VolumePath,
 				StoragePolicyName: pv.Spec.VsphereVolume.StoragePolicyName}
-			volumeHandle, err := volumeMigrationService.GetVolumeID(ctx, migrationVolumeSpec, true)
+			volumeHandle, err := volumeMigrationService.GetVolumeID(ctx, migrationVolumeSpec)
 			if err != nil {
 				log.Errorf("FullSync: Failed to get VolumeID from volumeMigrationService for spec: %v. Err: %+v",
 					migrationVolumeSpec, err)
@@ -174,7 +174,7 @@ func fullSyncCreateVolumes(ctx context.Context, createSpecArray []cnstypes.CnsVo
 			migrationVolumeSpec := &migration.VolumeSpec{
 				VolumePath:        pv.Spec.VsphereVolume.VolumePath,
 				StoragePolicyName: pv.Spec.VsphereVolume.StoragePolicyName}
-			volumeHandle, err := volumeMigrationService.GetVolumeID(ctx, migrationVolumeSpec, true)
+			volumeHandle, err := volumeMigrationService.GetVolumeID(ctx, migrationVolumeSpec)
 			if err != nil {
 				log.Errorf("FullSync: Failed to get VolumeID from volumeMigrationService for spec: %v. Err: %+v",
 					migrationVolumeSpec, err)
@@ -239,7 +239,7 @@ func fullSyncDeleteVolumes(ctx context.Context, volumeIDDeleteArray []cnstypes.C
 			migrationVolumeSpec := &migration.VolumeSpec{
 				VolumePath:        pv.Spec.VsphereVolume.VolumePath,
 				StoragePolicyName: pv.Spec.VsphereVolume.StoragePolicyName}
-			volumeHandle, err := volumeMigrationService.GetVolumeID(ctx, migrationVolumeSpec, true)
+			volumeHandle, err := volumeMigrationService.GetVolumeID(ctx, migrationVolumeSpec)
 			if err != nil {
 				log.Errorf("FullSync: Failed to get VolumeID from volumeMigrationService for spec: %v. Err: %+v",
 					migrationVolumeSpec, err)
@@ -391,7 +391,7 @@ func fullSyncConstructVolumeMaps(ctx context.Context, pvList []*v1.PersistentVol
 			migrationVolumeSpec := &migration.VolumeSpec{
 				VolumePath:        pv.Spec.VsphereVolume.VolumePath,
 				StoragePolicyName: pv.Spec.VsphereVolume.StoragePolicyName}
-			volumeHandle, err = volumeMigrationService.GetVolumeID(ctx, migrationVolumeSpec, true)
+			volumeHandle, err = volumeMigrationService.GetVolumeID(ctx, migrationVolumeSpec)
 			if err != nil {
 				log.Errorf("FullSync: Failed to get VolumeID from volumeMigrationService for spec: %v. Err: %+v",
 					migrationVolumeSpec, err)
@@ -473,7 +473,7 @@ func fullSyncGetVolumeSpecs(ctx context.Context, vCenterVersion string, pvList [
 			migrationVolumeSpec := &migration.VolumeSpec{
 				VolumePath:        pv.Spec.VsphereVolume.VolumePath,
 				StoragePolicyName: pv.Spec.VsphereVolume.StoragePolicyName}
-			volumeHandle, err = volumeMigrationService.GetVolumeID(ctx, migrationVolumeSpec, true)
+			volumeHandle, err = volumeMigrationService.GetVolumeID(ctx, migrationVolumeSpec)
 			if err != nil {
 				log.Warnf("FullSync: Failed to get VolumeID from volumeMigrationService for spec: %v. Err: %+v",
 					migrationVolumeSpec, err)

--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -880,7 +880,7 @@ func csiPVCUpdated(ctx context.Context, pvc *v1.PersistentVolumeClaim,
 		}
 		migrationVolumeSpec := &migration.VolumeSpec{VolumePath: pv.Spec.VsphereVolume.VolumePath,
 			StoragePolicyName: pv.Spec.VsphereVolume.StoragePolicyName}
-		volumeHandle, err = volumeMigrationService.GetVolumeID(ctx, migrationVolumeSpec, true)
+		volumeHandle, err = volumeMigrationService.GetVolumeID(ctx, migrationVolumeSpec)
 		if err != nil {
 			log.Errorf("PVC Updated: Failed to get VolumeID from volumeMigrationService for migration VolumeSpec: %v "+
 				"with error %+v", migrationVolumeSpec, err)
@@ -983,7 +983,7 @@ func csiPVCDeleted(ctx context.Context, pvc *v1.PersistentVolumeClaim,
 		}
 		migrationVolumeSpec := &migration.VolumeSpec{VolumePath: pv.Spec.VsphereVolume.VolumePath,
 			StoragePolicyName: pv.Spec.VsphereVolume.StoragePolicyName}
-		volumeHandle, err = volumeMigrationService.GetVolumeID(ctx, migrationVolumeSpec, true)
+		volumeHandle, err = volumeMigrationService.GetVolumeID(ctx, migrationVolumeSpec)
 		if err != nil {
 			log.Errorf("PVC Deleted: Failed to get VolumeID from volumeMigrationService for migration VolumeSpec: %v "+
 				"with error %+v", migrationVolumeSpec, err)
@@ -1036,7 +1036,7 @@ func csiPVUpdated(ctx context.Context, newPv *v1.PersistentVolume, oldPv *v1.Per
 		}
 		volumeHandle, err = volumeMigrationService.GetVolumeID(ctx,
 			&migration.VolumeSpec{VolumePath: newPv.Spec.VsphereVolume.VolumePath,
-				StoragePolicyName: newPv.Spec.VsphereVolume.StoragePolicyName}, true)
+				StoragePolicyName: newPv.Spec.VsphereVolume.StoragePolicyName})
 		if err != nil {
 			log.Errorf("PVUpdated: Failed to get VolumeID from volumeMigrationService for volumePath: %s with error %+v",
 				newPv.Spec.VsphereVolume.VolumePath, err)
@@ -1230,7 +1230,7 @@ func csiPVDeleted(ctx context.Context, pv *v1.PersistentVolume, metadataSyncer *
 			}
 			migrationVolumeSpec := &migration.VolumeSpec{VolumePath: pv.Spec.VsphereVolume.VolumePath,
 				StoragePolicyName: pv.Spec.VsphereVolume.StoragePolicyName}
-			volumeHandle, err = volumeMigrationService.GetVolumeID(ctx, migrationVolumeSpec, true)
+			volumeHandle, err = volumeMigrationService.GetVolumeID(ctx, migrationVolumeSpec)
 			if err != nil {
 				log.Errorf("PVDeleted: Failed to get VolumeID from volumeMigrationService for migration VolumeSpec: %v "+
 					"with error %+v", migrationVolumeSpec, err)
@@ -1295,7 +1295,7 @@ func csiUpdatePod(ctx context.Context, pod *v1.Pod, metadataSyncer *metadataSync
 					}
 					migrationVolumeSpec := &migration.VolumeSpec{VolumePath: pv.Spec.VsphereVolume.VolumePath,
 						StoragePolicyName: pv.Spec.VsphereVolume.StoragePolicyName}
-					volumeHandle, err = volumeMigrationService.GetVolumeID(ctx, migrationVolumeSpec, true)
+					volumeHandle, err = volumeMigrationService.GetVolumeID(ctx, migrationVolumeSpec)
 					if err != nil {
 						log.Errorf("Failed to get VolumeID from volumeMigrationService for migration VolumeSpec: %v "+
 							"with error %+v", migrationVolumeSpec, err)
@@ -1330,7 +1330,7 @@ func csiUpdatePod(ctx context.Context, pod *v1.Pod, metadataSyncer *metadataSync
 						return
 					}
 					migrationVolumeSpec := &migration.VolumeSpec{VolumePath: volume.VsphereVolume.VolumePath}
-					volumeHandle, err = volumeMigrationService.GetVolumeID(ctx, migrationVolumeSpec, true)
+					volumeHandle, err = volumeMigrationService.GetVolumeID(ctx, migrationVolumeSpec)
 					if err != nil {
 						log.Warnf("Failed to get VolumeID from volumeMigrationService for migration VolumeSpec: %v "+
 							"with error %+v", migrationVolumeSpec, err)

--- a/pkg/syncer/util.go
+++ b/pkg/syncer/util.go
@@ -85,7 +85,7 @@ func fullSyncGetInlineMigratedVolumesInfo(ctx context.Context,
 			if migrationFeatureState && volume.VsphereVolume != nil {
 				volumeHandle, err := volumeMigrationService.GetVolumeID(ctx,
 					&migration.VolumeSpec{VolumePath: volume.VsphereVolume.VolumePath,
-						StoragePolicyName: volume.VsphereVolume.StoragePolicyName}, true)
+						StoragePolicyName: volume.VsphereVolume.StoragePolicyName})
 				if err != nil {
 					log.Warnf(
 						"FullSync: Failed to get VolumeID from volumeMigrationService for volumePath: %s with error %+v",

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -561,6 +561,8 @@ gopkg.in/warnings.v0
 gopkg.in/yaml.v2
 # gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 gopkg.in/yaml.v3
+# honnef.co/go/tools v0.2.0
+## explicit
 # k8s.io/api v0.21.1 => k8s.io/api v0.21.1
 ## explicit
 k8s.io/api/admission/v1


### PR DESCRIPTION
This reverts commit 9d66b27b9b88a7ad11178ffa797b65c46f63a3ec, reversing changes made to ade36ffbb03aad6d7b186a7ff18bbe557b0d48a9.

This reverts PR https://github.com/openshift/vmware-vsphere-csi-driver/pull/30 and brings the CSI driver back to v2.4.0.

Upstream diff between v2.4.0 and v2.4.1: https://github.com/kubernetes-sigs/vsphere-csi-driver/compare/v2.4.0...v2.4.1 . The offending upstream commit that broke CSI migration is https://github.com/kubernetes-sigs/vsphere-csi-driver/pull/1398. As you can see, there are only few other commits between 2.4.0 and 2.4.1.

The other option would be to keep v2.4.1, but revert just the bad commit. We would effectively `<carry>` the revert until it's fixed upstream.
