### PR TITLE
OCPBUGS-7426: Add migrationDataStore field

### DIFF
--- a/pkg/common/cns-lib/vsphere/utils.go
+++ b/pkg/common/cns-lib/vsphere/utils.go
@@ -212,6 +212,7 @@ func GetVirtualCenterConfig(ctx context.Context, cfg *config.Config) (*VirtualCe
 		VCClientTimeout:                  vcClientTimeout,
 		QueryLimit:                       cfg.Global.QueryLimit,
 		ListVolumeThreshold:              cfg.Global.ListVolumeThreshold,
+		MigrationDataStoreURL:            cfg.VirtualCenter[host].MigrationDataStoreURL,
 	}
 
 	log.Debugf("Setting the queryLimit = %v, ListVolumeThreshold = %v", vcConfig.QueryLimit, vcConfig.ListVolumeThreshold)

--- a/pkg/common/cns-lib/vsphere/virtualcenter.go
+++ b/pkg/common/cns-lib/vsphere/virtualcenter.go
@@ -126,6 +126,9 @@ type VirtualCenterConfig struct {
 	// ListVolumeThreshold specifies the maximum number of differences in volume that
 	// can exist between CNS and kubernetes
 	ListVolumeThreshold int
+	// MigrationDataStore specifies datastore which is set as default datastore in legacy cloud-config
+	// and hence should be used as default datastore.
+	MigrationDataStoreURL string
 }
 
 // clientMutex is used for exclusive connection creation.

--- a/pkg/common/config/types.go
+++ b/pkg/common/config/types.go
@@ -148,6 +148,9 @@ type VirtualCenterConfig struct {
 	TargetvSANFileShareDatastoreURLs string `gcfg:"targetvSANFileShareDatastoreURLs"`
 	// TargetvSANFileShareClusters represents file service enabled vSAN clusters on which file volumes can be created.
 	TargetvSANFileShareClusters string `gcfg:"targetvSANFileShareClusters"`
+	// MigrationDataStore specifies datastore which is set as default datastore in legacy cloud-config
+	// and hence should be used as default datastore.
+	MigrationDataStoreURL string `gcfg:"migration-datastore-url"`
 }
 
 // GCConfig contains information used by guest cluster to access a supervisor

--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -453,6 +453,7 @@ func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolum
 		return nil, csifault.CSIInternalFault, logger.LogNewErrorCodef(log, codes.InvalidArgument,
 			"parsing storage class parameters failed with error: %+v", err)
 	}
+
 	if csiMigrationFeatureState && scParams.CSIMigration == "true" {
 		if len(scParams.Datastore) != 0 {
 			log.Infof("Converting datastore name: %q to Datastore URL", scParams.Datastore)
@@ -496,6 +497,8 @@ func (c *controller) createBlockVolume(ctx context.Context, req *csi.CreateVolum
 				return nil, csifault.CSIInternalFault, logger.LogNewErrorCodef(log, codes.Internal,
 					"failed to find datastoreURL for datastore name: %q", scParams.Datastore)
 			}
+		} else if c.manager.VcenterConfig.MigrationDataStoreURL != "" {
+			scParams.DatastoreURL = c.manager.VcenterConfig.MigrationDataStoreURL
 		}
 	}
 


### PR DESCRIPTION
Allow configuration of a datastore for migrated volumes

Fixes https://issues.redhat.com/browse/OCPBUGS-7426