### PR TITLE
OCPBUGS-10148,OCPBUGS-10152: Add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Keep Windows EOL in these files to have pristine vendor/ dir.
+vendor/github.com/MakeNowJust/heredoc/README.md text eol=crlf


### PR DESCRIPTION
`vendor/github.com/MakeNowJust/heredoc/README.md` has lost Windows `\r\n` line endings during the last rebase and now our [verify-deps CI job complains about it](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_vmware-vsphere-csi-driver/62/pull-ci-openshift-vmware-vsphere-csi-driver-master-verify-deps/1633973213337751552).

Add `.gitattributes` to prevent further end-of-line changes in this file.
