### PR TITLE
OCPBUGS-12718: Fix .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 # Keep Windows EOL in these files to have pristine vendor/ dir.
-vendor/github.com/MakeNowJust/heredoc/README.md text eol=crlf
+vendor/github.com/MakeNowJust/heredoc/README.md text=auto eol=crlf


### PR DESCRIPTION
After #63 and #70 landed, it's happening a weird behavior when cloning this repository. After cloning, it randomly gets into a dirty state with that `vendor/github.com/MakeNowJust/heredoc/README.md` file changed.

I got it as a Buildconfig building from this repository (OKD related and outside of the Prow CI) is randomly failing since yesterday because the changed file prevents checking out another branch (e.g., release-4.13) after cloning the master one. (as in git clone ... && git checkout ...):

```
Cloning "https://github.com/openshift/vmware-vsphere-csi-driver" ...
error: Your local changes to the following files will be overwritten by checkout:
vendor/github.com/MakeNowJust/heredoc/README.md
Please commit your changes or stash them before you switch branches.
Aborting
```

As this happens randomly, the issue escaped the pre/post submit prow jobs verification (that should execute similarly), but it could happen eventually.

This PR proposes to use `text=auto` rather than only `text` in the .gitattributes file rule of the above-mentioned file.

From the official git doc:

```
Set
    Setting the text attribute on a path enables end-of-line normalization and marks the path as a text file. End-of-line conversion takes place without guessing the content type.
Set to string value "auto"
    When text is set to "auto", the path is marked for automatic end-of-line conversion. If Git decides the content is text, its line endings are converted to LF on checkin. When the file has been committed with CRLF, no conversion is done.
```

I'm not 100% sure this is the fix we need, but the change in my branch fixes the below test that shows the failure in my runs.

What I did to reproduce the issue was execute this script in various environments:

```bash
#!/bin/bash
#

failures=0
n_tests=100
for i in $(seq 1 $n_tests); do
    echo
    echo "test $i..."
    tmpdir=$(mktemp -d)
    git clone https://github.com/openshift/vmware-vsphere-csi-driver "${tmpdir}"
    pushd "${tmpdir}" || continue
    echo git status:
    git status -s
    git diff --exit-code -s || {
        failures=$(( failures + 1 ))
        echo "** DETECTED DIFF **"
    }
    popd || continue
    rm -rf "$tmpdir"
done

echo "N. Tests: $n_tests - Failed (detected changes after clone): ${failures}"

```

## Executions without the change in this PR:

- locally (Fedora Rawhide) - git version 2.40.0
```
N. Tests: 100 - Failed (detected changes after clone): 17
```
- on a podman container (quay.io/centos/centos:stream9) - git version 2.39.1
```
N. Tests: 100 - Failed (detected changes after clone): 16
```
- on a podman container (quay.io/fedora/fedora:latest) - git version 2.39.2
```
N. Tests: 100 - Failed (detected changes after clone): 13
```
- on an OCP pod using the same image of the BuildConfigs's init container (git-clone):
  - git version: 2.31.1
  - ocp version: 4.13.0-rc.0 (multiarch)
  - image: `quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:1f90e43a6753b35b82a036ba3d2e2465ce12380428380b4ccfb4e03a1b2f2f7f`
```
N. Tests: 100 - Failed (detected changes after clone): 23
```

## Execution with the change in this PR:

I never got a failure in any of the environments.
I also verified that the checkout of the release-4.13 branch succeeds and that the CRLF characters are kept in the file.