### PR TITLE
OCPBUGS-13386: Fix use of GetNodeByName when using node's VMUUID (#2387)

### DIFF
--- a/pkg/common/cns-lib/node/manager.go
+++ b/pkg/common/cns-lib/node/manager.go
@@ -60,6 +60,9 @@ type Manager interface {
 	// GetNodeByName refreshes and returns the VirtualMachine for a registered
 	// node given its name.
 	GetNodeByName(ctx context.Context, nodeName string) (*vsphere.VirtualMachine, error)
+	// GetNodeByNameOrUUID refreshes and returns VirtualMachine for a registered node
+	// using either its name or UUID.
+	GetNodeByNameOrUUID(ctx context.Context, nodeName string) (*vsphere.VirtualMachine, error)
 	// GetNodeNameByUUID fetches the name of the node given the VM UUID.
 	GetNodeNameByUUID(ctx context.Context, nodeUUID string) (string, error)
 	// GetAllNodes refreshes and returns VirtualMachine for all registered
@@ -170,6 +173,27 @@ func (m *defaultManager) GetNodeByName(ctx context.Context, nodeName string) (*v
 	m.nodeNameToUUID.Store(nodeName, k8snodeUUID)
 	return m.GetNode(ctx, k8snodeUUID, nil)
 
+}
+
+func (m *defaultManager) GetNodeByNameOrUUID(
+	ctx context.Context, nodeNameOrUUID string) (*vsphere.VirtualMachine, error) {
+	log := logger.GetLogger(ctx)
+	nodeUUID, found := m.nodeNameToUUID.Load(nodeNameOrUUID)
+	if !found {
+		log.Errorf("Node not found with nodeName %s", nodeNameOrUUID)
+		return nil, ErrNodeNotFound
+	}
+	if nodeUUID != nil && nodeUUID.(string) != "" {
+		return m.GetNode(ctx, nodeUUID.(string), nil)
+	}
+	log.Infof("Empty nodeUUID observed in cache for the node: %q", nodeNameOrUUID)
+	k8snodeUUID, err := k8s.GetNodeUUID(ctx, m.k8sClient, nodeNameOrUUID, m.useNodeUuid)
+	if err != nil {
+		log.Errorf("failed to get node UUID from node: %q. Err: %v", nodeNameOrUUID, err)
+		return nil, err
+	}
+	m.nodeNameToUUID.Store(nodeNameOrUUID, k8snodeUUID)
+	return m.GetNode(ctx, k8snodeUUID, nil)
 }
 
 // GetNodeNameByUUID fetches the name of the node given the VM UUID.

--- a/pkg/common/cns-lib/node/nodes.go
+++ b/pkg/common/cns-lib/node/nodes.go
@@ -190,6 +190,13 @@ func (nodes *Nodes) GetNodeByName(ctx context.Context, nodeName string) (
 	return nodes.cnsNodeManager.GetNodeByName(ctx, nodeName)
 }
 
+// GetNodeByNameOrUUID returns VirtualMachine object for given nodeName
+// This function can be called either using nodeName or nodeUID.
+func (nodes *Nodes) GetNodeByNameOrUUID(
+	ctx context.Context, nodeNameOrUUID string) (*cnsvsphere.VirtualMachine, error) {
+	return nodes.cnsNodeManager.GetNodeByNameOrUUID(ctx, nodeNameOrUUID)
+}
+
 // GetNodeNameByUUID fetches the name of the node given the VM UUID.
 func (nodes *Nodes) GetNodeNameByUUID(ctx context.Context, nodeUUID string) (
 	string, error) {

--- a/pkg/csi/service/vanilla/controller.go
+++ b/pkg/csi/service/vanilla/controller.go
@@ -61,6 +61,7 @@ type NodeManagerInterface interface {
 	Initialize(ctx context.Context, useNodeUuid bool) error
 	GetSharedDatastoresInK8SCluster(ctx context.Context) ([]*cnsvsphere.DatastoreInfo, error)
 	GetNodeByName(ctx context.Context, nodeName string) (*cnsvsphere.VirtualMachine, error)
+	GetNodeByNameOrUUID(ctx context.Context, nodeName string) (*cnsvsphere.VirtualMachine, error)
 	GetNodeNameByUUID(ctx context.Context, nodeUUID string) (string, error)
 	GetNodeByUuid(ctx context.Context, nodeUuid string) (*cnsvsphere.VirtualMachine, error)
 	GetAllNodes(ctx context.Context) ([]*cnsvsphere.VirtualMachine, error)
@@ -2115,7 +2116,7 @@ func (c *controller) ControllerPublishVolume(ctx context.Context, req *csi.Contr
 			if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.UseCSINodeId) {
 				// if node is not yet updated to run the release of the driver publishing Node VM UUID as Node ID
 				// look up Node by name
-				nodevm, err = c.nodeMgr.GetNodeByName(ctx, req.NodeId)
+				nodevm, err = c.nodeMgr.GetNodeByNameOrUUID(ctx, req.NodeId)
 				if err == node.ErrNodeNotFound {
 					log.Infof("Performing node VM lookup using node VM UUID: %q", req.NodeId)
 					nodevm, err = c.nodeMgr.GetNodeByUuid(ctx, req.NodeId)
@@ -2256,7 +2257,7 @@ func (c *controller) ControllerUnpublishVolume(ctx context.Context, req *csi.Con
 		if commonco.ContainerOrchestratorUtility.IsFSSEnabled(ctx, common.UseCSINodeId) {
 			// if node is not yet updated to run the release of the driver publishing Node VM UUID as Node ID
 			// look up Node by name
-			nodevm, err = c.nodeMgr.GetNodeByName(ctx, req.NodeId)
+			nodevm, err = c.nodeMgr.GetNodeByNameOrUUID(ctx, req.NodeId)
 			if err == node.ErrNodeNotFound {
 				log.Infof("Performing node VM lookup using node VM UUID: %q", req.NodeId)
 				nodevm, err = c.nodeMgr.GetNodeByUuid(ctx, req.NodeId)

--- a/pkg/csi/service/vanilla/controller_test.go
+++ b/pkg/csi/service/vanilla/controller_test.go
@@ -246,6 +246,11 @@ func (f *FakeNodeManager) GetNodeByName(ctx context.Context, nodeName string) (*
 	return vm, nil
 }
 
+func (f *FakeNodeManager) GetNodeByNameOrUUID(
+	ctx context.Context, nodeNameOrUUID string) (*cnsvsphere.VirtualMachine, error) {
+	return f.GetNodeByName(ctx, nodeNameOrUUID)
+}
+
 func (f *FakeNodeManager) GetNodeNameByUUID(ctx context.Context, nodeUUID string) (string, error) {
 	return "", nil
 }


### PR DESCRIPTION
Fixes OCPBUGS-13386