### PR TITLE
OCPBUGS-16783: Chore: Update OWNERS and OWNERS_ALIASES

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,4 +1,3 @@
 approvers:
 - openshift-storage-maintainers
-component: "Storage"
-subcomponent: Kubernetes External Components
+component: "Storage / Kubernetes External Components"

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -5,3 +5,5 @@ aliases:
     - dobsonj
     - jsafrane
     - tsmetana
+    - RomanBednar
+    - mpatlasov


### PR DESCRIPTION
Changing the component as per the other Storage repos and adding Roman and Maxim in storage maintainers.

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Testing done**:
A PR must be marked "[WIP]", if no test result is provided. A WIP PR won't be reviewed, nor merged.
The requester can determine a sufficient test, e.g. build for a cosmetic change, E2E test in a predeployed setup, etc.
For new features, new tests should be done, in addition to regression tests.
If jtest is used to trigger precheckin tests, paste the result after jtest completes and remove [WIP] in the PR subject.
The review cycle will start, only after "[WIP]" is removed from the PR subject.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
