### PR TITLE
OCPBUGS-13551: FailedPrecondition volume does not appear staged

### DIFF
--- a/pkg/csi/service/osutils/linux_os_utils.go
+++ b/pkg/csi/service/osutils/linux_os_utils.go
@@ -825,7 +825,14 @@ func (osUtils *OsUtils) GetDevMounts(ctx context.Context,
 		return devMnts, err
 	}
 	for _, m := range mnts {
-		if m.Device == sysDevice.RealDev || (m.Device == "devtmpfs" && m.Source == sysDevice.RealDev) {
+		// the device in the mount table may be a symlink
+		realDev, err := filepath.EvalSymlinks(m.Device)
+		if err != nil {
+			realDev = m.Device
+		}
+
+		if m.Device == sysDevice.RealDev || realDev == sysDevice.RealDev ||
+			(m.Device == "devtmpfs" && m.Source == sysDevice.RealDev) {
 			devMnts = append(devMnts, m)
 		}
 	}


### PR DESCRIPTION
Each Device object has a RealDev field showing the underlying device
path after resolving symlinks. GetDevMounts checks each device in the
mount table against the RealDev field and only returns mounts for that
device. However, the mount table may have symlinks, such as /dev/mapper
devices, and it should resolve those before comparing to RealDev.

Marking this WIP until upstream PR merges, want to run presubmit jobs in the mean time.

https://issues.redhat.com/browse/OCPBUGS-13551

cc @openshift/storage
