### PR TITLE
WIP: DO_NOT_MERGE: Debug `e2e-vsphere-csi` test

### DIFF
--- a/pkg/csi/service/server.go
+++ b/pkg/csi/service/server.go
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Dummy change
+
 package service
 
 import (


### PR DESCRIPTION
A bunch of tests in [PR#95](https://github.com/openshift/vmware-vsphere-csi-driver/pull/95) failed with:

```
* 2023-10-19T22:06:34Z 1x kubelet: Started container place-entrypoint
* 2023-10-19T22:08:02Z 4x kubelet: Pulling image "registry.ci.openshift.org/ci/entrypoint-wrapper:latest"
* 2023-10-19T22:08:03Z 4x kubelet: Failed to pull image "registry.ci.openshift.org/ci/entrypoint-wrapper:latest": rpc error: code = Unknown desc = fetching target platform image selected from manifest list: reading manifest sha256:23c4b21ba4577aa5dca9820c64498101ca6ab99be3bbb312cc0d96ff0d69268f in registry.ci.openshift.org/ci/entrypoint-wrapper: manifest unknown
* 2023-10-19T22:08:03Z 4x kubelet: Error: ErrImagePull
* 2023-10-19T22:07:51Z 5x kubelet: Back-off pulling image "registry.ci.openshift.org/ci/entrypoint-wrapper:latest"
* 2023-10-19T22:07:51Z 5x kubelet: Error: ImagePullBackOff
```

Let's look if it's reproducible with this NOOP PR.