### PR TITLE
[release-4.12] OCPBUGS-20417: syncer: fix nil pointer dereference in log message

### DIFF
--- a/pkg/syncer/metadatasyncer.go
+++ b/pkg/syncer/metadatasyncer.go
@@ -960,7 +960,7 @@ func podAdded(obj interface{}, metadataSyncer *metadataSyncInformer) {
 						if err != nil {
 							log.Warnf("podAdded: Failed to get VolumeID from "+
 								"volumeMigrationService for static PV: %q volumePath: %q with error %+v",
-								pv.Name, volume.VsphereVolume.VolumePath, err)
+								pv.Name, pv.Spec.VsphereVolume.VolumePath, err)
 							continue
 						}
 						log.Infof("Successfully registered in-tree vSphere inline volume: %q with "+


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-20417

This is a manual backport of https://github.com/openshift/vmware-vsphere-csi-driver/commit/6de63b32bd4308f0ff689b6657a2201bd2dcebd1

This fix already exists in 4.13+

/cc @openshift/storage @duanwei33
