### PR TITLE
OCPBUGS-27242: fix or ignore snyk errors for ocp storage repos

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -4,3 +4,5 @@
 exclude:
   global:
     - vendor/**
+    - tests/**
+    - "**/*_test.go"


### PR DESCRIPTION
Ignore these snyk errors. Lots of complaints about hardcoded credentials in e2e and unit tests (but no real credentials and nothing worth fixing IMO).

```
 ✗ [Low] Use of Hardcoded Credentials
   ID: 602b9960-4fad-4440-ad69-85dea373fc7c 
   Path: tests/e2e/vsan_stretched_cluster.go, line 131 
   Info: Do not hardcode credentials in code. Found hardcoded credential used in User.
 ✗ [Low] Use of Hardcoded Credentials
   ID: fd883631-52c7-48ee-a6e3-d0f1e13abdb7 
   Path: tests/e2e/config_secret.go, line 95 
   Info: Do not hardcode credentials in code. Found hardcoded credential used in User.
 ✗ [Low] Use of Hardcoded Credentials
   ID: b97e0c3d-7836-4879-959f-fad609a60717 
   Path: tests/e2e/preferential_topology.go, line 107 
   Info: Do not hardcode credentials in code. Found hardcoded credential used in User.
 ✗ [Low] Use of Hardcoded Credentials
   ID: 9d1f26a8-b3c5-4828-8e4b-d0679f5e384a 
   Path: tests/e2e/preferential_topology_disruptive.go, line 100 
   Info: Do not hardcode credentials in code. Found hardcoded credential used in User.
 ✗ [Low] Use of Hardcoded Credentials
   ID: 98633a4f-05ec-4188-a88b-7beaedf54a96 
   Path: tests/e2e/util.go, line 3808 
   Info: Do not hardcode credentials in code. Found hardcoded credential used in User.
 ✗ [Low] Use of Hardcoded Credentials
   ID: 4929863d-2f98-4056-8430-0dba7554fb65 
   Path: tests/e2e/util.go, line 4294 
   Info: Do not hardcode credentials in code. Found hardcoded credential used in User.
 ✗ [Low] Use of Hardcoded Credentials
   ID: c49a1ac0-49ce-4cb3-90d5-63c019e992a9 
   Path: tests/e2e/topology_operation_strom_cases.go, line 96 
   Info: Do not hardcode credentials in code. Found hardcoded credential used in User.
 ✗ [Low] Use of Hardcoded Credentials
   ID: 83dc24b4-6a18-49b0-854d-090b6d3e9d9e 
   Path: tests/e2e/topology_multi_replica.go, line 120 
   Info: Do not hardcode credentials in code. Found hardcoded credential used in User.
 ✗ [Low] Use of Hardcoded Credentials
   ID: 675c5875-4278-4dfd-8dd6-837ef8dfe8a1 
   Path: tests/e2e/preferential_topology_snapshot.go, line 120 
   Info: Do not hardcode credentials in code. Found hardcoded credential used in User.
 ✗ [Low] Use of Hardcoded Credentials
   ID: 82dd36ca-5a65-4942-b109-ecc434c0c2b8 
   Path: tests/e2e/vsan_stretched_cluster_utils.go, line 572 
   Info: Do not hardcode credentials in code. Found hardcoded credential used in User.
 ✗ [Low] Use of Hardcoded Credentials
   ID: d8ae7f8c-7d32-44a4-b5ae-caeabe8b5c91 
   Path: tests/e2e/statefulsets.go, line 90 
   Info: Do not hardcode credentials in code. Found hardcoded credential used in User.
 ✗ [Low] Use of Hardcoded Credentials
   ID: 0f50045d-5410-4213-91dd-6a21c175644f 
   Path: tests/e2e/csi_snapshot_basic.go, line 4260 
   Info: Do not hardcode credentials in code. Found hardcoded credential used in User.
 ✗ [Low] Use of Hardcoded Credentials
   ID: 107976f0-c220-43a9-8b3a-1b2f1e34a164 
   Path: tests/e2e/topology_site_down_cases.go, line 89 
   Info: Do not hardcode credentials in code. Found hardcoded credential used in User.
 ✗ [Low] Use of Hardcoded Credentials
   ID: f3cd692a-9648-40f1-bbf4-b725f644e49a 
   Path: pkg/syncer/admissionhandler/validatepvcannotationforvolumehealth_test.go, line 51 
   Info: Do not hardcode credentials in code. Found hardcoded credential used in _.
 ✗ [Low] Use of Hardcoded Credentials
   ID: 47c4eee8-9ec0-4de2-8ecc-7ec70d23bf4a 
   Path: pkg/syncer/admissionhandler/validatepvcannotationforvolumehealth_test.go, line 68 
   Info: Do not hardcode credentials in code. Found hardcoded credential used in _.
 ✗ [Low] Use of Hardcoded Credentials
   ID: cbc3ad3f-dece-4e87-b6e9-3d77b2ab55c1 
   Path: pkg/syncer/admissionhandler/validatepvcannotationforvolumehealth_test.go, line 84 
   Info: Do not hardcode credentials in code. Found hardcoded credential used in _.
 ✗ [Low] Use of Hardcoded Credentials
   ID: 66be7770-6bba-4f87-a373-e46ed733003d 
   Path: pkg/syncer/admissionhandler/validatepvcannotationforvolumehealth_test.go, line 100 
   Info: Do not hardcode credentials in code. Found hardcoded credential used in _.
 ✗ [Low] Use of Hardcoded Credentials
   ID: b9f42bae-389c-4cc3-b1e2-2b6688157b9c 
   Path: pkg/syncer/admissionhandler/validatepvcannotationforvolumehealth_test.go, line 120 
   Info: Do not hardcode credentials in code. Found hardcoded credential used in _.
 ✗ [Low] Use of Hardcoded Credentials
   ID: 896ffd96-5066-4e9d-9c02-f3499a9197e7 
   Path: pkg/syncer/admissionhandler/validatepvcannotationforvolumehealth_test.go, line 140 
   Info: Do not hardcode credentials in code. Found hardcoded credential used in _.
 ✗ [Low] Use of Hardcoded Credentials
   ID: dd73e424-0ab8-42fa-a560-4c14bd804051 
   Path: pkg/syncer/admissionhandler/validatepvcannotationforvolumehealth_test.go, line 159 
   Info: Do not hardcode credentials in code. Found hardcoded credential used in _.
 ✗ [Low] Use of Hardcoded Credentials
   ID: 9814ba4d-f9f9-49e1-aa4e-9823ebcf77f7 
   Path: pkg/syncer/admissionhandler/validatepvcannotationforvolumehealth_test.go, line 178 
   Info: Do not hardcode credentials in code. Found hardcoded credential used in _.
 ✗ [Low] Use of Hardcoded Credentials
   ID: a7a99ac0-f974-4d5e-a877-a3e4349ee9c4 
   Path: pkg/syncer/admissionhandler/validatepvcannotationforvolumehealth_test.go, line 198 
   Info: Do not hardcode credentials in code. Found hardcoded credential used in _.
 ✗ [Low] Improper Certificate Validation
   ID: 55c9a0a6-4db2-481d-8987-f1815198e8ad 
   Path: tests/e2e/util.go, line 1478 
   Info: TrustManager might be too permissive: The client will accept any certificate and any host name in that certificate, making it susceptible to man-in-the-middle attacks.
 ✗ [Low] Improper Certificate Validation
   ID: 5c6eaed7-24e8-4359-8863-f845b43cfc02 
   Path: tests/e2e/util.go, line 1502 
   Info: TrustManager might be too permissive: The client will accept any certificate and any host name in that certificate, making it susceptible to man-in-the-middle attacks.
 ✗ [Low] Improper Certificate Validation
   ID: 0be1e0fa-6be7-467e-b1b8-2ea9fc82e638 
   Path: tests/e2e/util.go, line 1553 
   Info: TrustManager might be too permissive: The client will accept any certificate and any host name in that certificate, making it susceptible to man-in-the-middle attacks.
 ✗ [Low] Improper Certificate Validation
   ID: e2eae2fb-db28-458a-b584-15706c9ecace 
   Path: tests/e2e/util.go, line 1602 
   Info: TrustManager might be too permissive: The client will accept any certificate and any host name in that certificate, making it susceptible to man-in-the-middle attacks.
 ✗ [Low] Improper Certificate Validation
   ID: a78033fb-9ec0-4558-acf1-8923e53308aa 
   Path: tests/e2e/util.go, line 1628 
   Info: TrustManager might be too permissive: The client will accept any certificate and any host name in that certificate, making it susceptible to man-in-the-middle attacks.
 ✗ [Low] Improper Certificate Validation
   ID: f600c8f4-eb14-433f-905c-2045c5a71c59 
   Path: tests/e2e/util.go, line 1657 
   Info: TrustManager might be too permissive: The client will accept any certificate and any host name in that certificate, making it susceptible to man-in-the-middle attacks.
 ✗ [Low] Improper Certificate Validation
   ID: f37c9078-194c-46cb-807c-5e0da93d74fd 
   Path: tests/e2e/util.go, line 1682 
   Info: TrustManager might be too permissive: The client will accept any certificate and any host name in that certificate, making it susceptible to man-in-the-middle attacks.
 ✗ [Low] Improper Certificate Validation
   ID: cc70c0f4-ad8b-4fb3-bf8e-acd2b95ff437 
   Path: tests/e2e/util.go, line 1716 
   Info: TrustManager might be too permissive: The client will accept any certificate and any host name in that certificate, making it susceptible to man-in-the-middle attacks.
 ✗ [Low] Improper Certificate Validation
   ID: f6caf5bc-a4be-4667-822d-387b087eaa0f 
   Path: tests/e2e/util.go, line 1755 
   Info: TrustManager might be too permissive: The client will accept any certificate and any host name in that certificate, making it susceptible to man-in-the-middle attacks.
 ✗ [Low] Improper Certificate Validation
   ID: 08ef8763-2bd5-44a1-92dd-e62554ea2828 
   Path: tests/e2e/util.go, line 1789 
   Info: TrustManager might be too permissive: The client will accept any certificate and any host name in that certificate, making it susceptible to man-in-the-middle attacks.
 ✗ [Low] Improper Certificate Validation
   ID: 1669ea4d-a061-4549-a4d1-4adefb5d7339 
   Path: tests/e2e/util.go, line 1842 
   Info: TrustManager might be too permissive: The client will accept any certificate and any host name in that certificate, making it susceptible to man-in-the-middle attacks.
 ✗ [Low] Improper Certificate Validation
   ID: 75d0ffb5-a1b2-4f2a-a604-59e45b864e70 
   Path: tests/e2e/util.go, line 1873 
   Info: TrustManager might be too permissive: The client will accept any certificate and any host name in that certificate, making it susceptible to man-in-the-middle attacks.
 ✗ [Low] Improper Certificate Validation
   ID: d2580bd2-e3e7-490e-8ceb-d4af44f3a60f 
   Path: tests/e2e/util.go, line 1904 
   Info: TrustManager might be too permissive: The client will accept any certificate and any host name in that certificate, making it susceptible to man-in-the-middle attacks.
 ✗ [Low] Use of Hardcoded Credentials
   ID: 8cec91d5-785c-4fbd-bbbb-69eb00b013e1 
   Path: tests/e2e/e2e_common.go, line 127 
   Info: Do not hardcode passwords in code. Found hardcoded saved in passorwdFilePath.
 ✗ [Low] Use of Hardcoded Credentials
   ID: c4a4d940-8e7c-4686-81b2-3d8916dca2aa 
   Path: tests/e2e/e2e_common.go, line 163 
   Info: Do not hardcode passwords in code. Found hardcoded saved in svcMasterPassword.
```

from https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/47618/rehearse-47618-pull-ci-openshift-vmware-vsphere-csi-driver-master-security/1745954195053219840

/cc @openshift/storage
